### PR TITLE
perf(phpstan): add memory limit 1G

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ db:
 
 .PHONY: phpstan
 phpstan:
-	docker compose exec backend bash -c 'vendor/bin/phpstan clear-result-cache && vendor/bin/phpstan analyse'
+	docker compose exec backend bash -c 'vendor/bin/phpstan clear-result-cache && vendor/bin/phpstan analyse --memory-limit 1G'
 
 .PHONY: pint
 pint:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,7 +20,7 @@ pre-commit:
     phpstan:
       root: backend
       glob: "*.php"
-      run: docker compose exec backend bash -c 'vendor/bin/phpstan clear-result-cache && vendor/bin/phpstan analyse {staged_files}'
+      run: docker compose exec backend bash -c 'vendor/bin/phpstan clear-result-cache && vendor/bin/phpstan analyse --memory-limit 1G {staged_files}'
     pint:
       root: backend
       glob: "*.php"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改良**
  - `phpstan` のメモリ制限を 1G に拡張し、パフォーマンスを向上。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->