### PR TITLE
feat: migrate, comics table

### DIFF
--- a/backend/database/migrations/2024_07_21_142506_create_comics_table.php
+++ b/backend/database/migrations/2024_07_21_142506_create_comics_table.php
@@ -15,7 +15,7 @@ return new class() extends Migration
     {
         Schema::create('comics', function (Blueprint $table) {
             $table->id();
-            $table->string('key')
+            $table->string('key', 255)
                 ->unique();
             $table->text('name');
             $table->enum('status', ['published', 'draft', 'closed'])

--- a/backend/database/migrations/2024_07_21_142506_create_comics_table.php
+++ b/backend/database/migrations/2024_07_21_142506_create_comics_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('comics', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')
+                ->unique();
+            $table->text('name');
+            $table->enum('status', ['published', 'draft', 'closed'])
+                ->default('draft');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('comics');
+    }
+};

--- a/backend/database/migrations/2024_07_21_142506_create_comics_table.php
+++ b/backend/database/migrations/2024_07_21_142506_create_comics_table.php
@@ -20,6 +20,7 @@ return new class() extends Migration
             $table->text('name');
             $table->enum('status', ['published', 'draft', 'closed'])
                 ->default('draft');
+            $table->index('status');
             $table->timestamps();
             $table->softDeletes();
         });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
	- コミックテーブルをデータベースに追加し、公開、下書き、またはクローズのステータスを持つコミックの管理を可能にしました。
	- ソフトデリート機能を導入し、削除されたレコードを完全に削除することなく管理できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->