### PR TITLE
fix: docker entrypoint initdb, grant command

### DIFF
--- a/docker/db/docker-entrypoint-initdb.d/01_create_testing_database.sql
+++ b/docker/db/docker-entrypoint-initdb.d/01_create_testing_database.sql
@@ -1,3 +1,3 @@
 CREATE DATABASE IF NOT EXISTS `testing` DEFAULT CHARACTER SET utf8 ;
-GRANT ALL ON `testing`.* TO 'root@'%' ;
+GRANT ALL ON `testing`.* TO root@'%' ;
 FLUSH PRIVILEGES ;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
	- テスト用データベースの初期化スクリプトにおけるユーザー識別子の構文を修正しました。これにより、ユーザーのアクセス権限が適切に設定されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->