### PR TITLE
fix: paginate

### DIFF
--- a/backend/packages/UseCase/Comic/Index/ComicIndexResponse.php
+++ b/backend/packages/UseCase/Comic/Index/ComicIndexResponse.php
@@ -15,7 +15,7 @@ class ComicIndexResponse implements ResponseInterface
     {
         return [
             'comics' => $this->buildComics(),
-            'pagination' => $this->comics->getPagination()->toArray(),
+            'pagination' => $this->comics->count() ? $this->comics->getPagination()->toArray() : [],
         ];
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - コミックのページネーションデータが、コミックが存在する場合のみ返されるようになりました。これにより、空のコレクションに対する誤解を招くページネーションデータの問題が解消されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->